### PR TITLE
Add startTime, endTime, and location fields to task model and update endpoints

### DIFF
--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -45,6 +45,9 @@ const postTask = asyncHandler(async (req, res) => {
   const task = await Task.create({
     name: req.body.name,
     user: req.user.id,
+    startTime: req.body.startTime,
+    endTime: req.body.endTime,
+    location: req.body.location,
   });
 
   res.status(200).json(task);

--- a/backend/models/taskModel.js
+++ b/backend/models/taskModel.js
@@ -14,6 +14,18 @@ const taskSchema = mongoose.Schema(
       type: String,
       required: [true, "Name field required"],
     },
+    startTime: {
+      type: Number,
+      required: false,
+    },
+    endTime: {
+      type: Number,
+      required: false,
+    },
+    location: {
+      type: [Number],
+      required: false,
+    }
   },
   {
     timestamps: true,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -370,10 +370,10 @@ components:
           type: string
           description: The search query
         skip:
-          type: number
+          type: integer
           description: The number of results to skip
         limit:
-          type: number
+          type: integer
           description: The number of results to limit the search to
     UserRegister:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -306,6 +306,19 @@ components:
         name:
           type: string
           description: The name of the task
+        startTime:
+          type: number
+          description: The start time of the task in UNIX milliseconds
+        endTime:
+          type: number
+          description: The end time of the task in UNIX milliseconds
+        location:
+          description: The location of the task
+          type: array
+          maxItems: 2
+          minItems: 2
+          items:
+            type: number
       required:
         - name
     Task:
@@ -320,6 +333,18 @@ components:
         name:
           type: string
           description: The name of the task
+        startTime:
+          type: number
+          description: The start of the task in UNIX milliseconds
+        endTime:
+          type: number
+          description: The end of the task in UNIX milliseconds
+        location:
+          type: array
+          maxItems: 2
+          minItems: 2
+          items:
+            type: number
         createdAt:
           type: string
           description: The time this task was created


### PR DESCRIPTION
What the title says. This PR adds full CRUD support for `startTime`, `endTime`, and location coordinates. `startTime` and `endTime` are numbers, `location` is a pair of numbers.